### PR TITLE
Rename scripts and fix build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,9 @@ venv.bak/
 ### VisualStudioCode ###
 .vscode/*
 
+# vim
+*.swp
+
 .history
 
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "Alfredo Miranda <alfredo@miranda.io>"
   ],
   "scripts": {
-    "start": "nodemon ./src/index.js --exec babel-node -e js",
-    "build": "babel src -d dist && cp src/schema.gql dist/schema.gql",
-    "serve": "node dist/index.js"
+    "start": "node dist/index.js",
+    "build": "babel src -d dist",
+    "dev": "nodemon ./src/index.js --exec babel-node -e js"
   },
   "dependencies": {
     "apollo-server-express": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "start": "node dist/index.js",
-    "build": "babel src -d dist",
+    "build": "babel src -d dist && cp src/constants/uniprotSubCellularLocations.json src/constants/keywlist.txt dist/constants",
     "dev": "nodemon ./src/index.js --exec babel-node -e js"
   },
   "dependencies": {


### PR DESCRIPTION
This PR renames the `serve` script to `start` since `now` uses the `start` script by convention to start the server. This PR also modifies the `build` script to copy some files into the `dist` directory.