### PR TITLE
Add several drug related fields to API

### DIFF
--- a/src/public/apis/dataloaders.js
+++ b/src/public/apis/dataloaders.js
@@ -631,6 +631,18 @@ export const createDrugLoader = () =>
           }),
         }));
 
+        // linked targets is just the set from the mechanisms of action
+        // previously was besthitsearch, but this required evidence strings,
+        // so only picked up targets such that t-dr-d relationship known
+        const linkedTargets = Object.values(
+          mechanismsOfAction.reduce((acc, m) => {
+            m.targets.forEach(t => {
+              acc[t.id] = t;
+            });
+            return acc;
+          }, {})
+        );
+
         const uniqueActionTypes = _.uniq(
           mechanismsOfActionRaw.map(m => m.action_type)
         );
@@ -649,6 +661,7 @@ export const createDrugLoader = () =>
           mechanismsOfAction,
           uniqueActionTypes,
           uniqueTargetTypes,
+          linkedTargets,
         };
       });
     })

--- a/src/public/apis/openTargets.js
+++ b/src/public/apis/openTargets.js
@@ -14,6 +14,19 @@ export const drugs = chemblIds =>
     Promise.resolve(chemblIds),
     Promise.all(chemblIds.map(chemblId => drug(chemblId))),
   ]);
+export const drugDiseases = drugName =>
+  axios
+    .get(
+      `${ROOT}public/search?q=${drugName}&size=1000&filter=disease&search_profile=drug`
+    )
+    .then(response =>
+      response.data.data.map(d => ({
+        id: d.data.id,
+        name: d.data.name,
+        description: d.data.description,
+      }))
+    );
+
 export const disease = efoId => axios.get(`${ROOT}private/disease/${efoId}`);
 export const diseases = efoIds =>
   Promise.all([

--- a/src/public/schema/common/sections/Drugs.js
+++ b/src/public/schema/common/sections/Drugs.js
@@ -39,7 +39,7 @@ export const typeDefs = gql`
     sourceUrl: String!
     sourceName: String!
   }
-  type MechanismOfAction {
+  type EvidenceMechanismOfAction {
     name: String!
     sourceUrl: String
     sourceName: String
@@ -49,6 +49,6 @@ export const typeDefs = gql`
     disease: Disease!
     drug: EvDrug!
     clinicalTrial: ClinicalTrial!
-    mechanismOfAction: MechanismOfAction!
+    mechanismOfAction: EvidenceMechanismOfAction!
   }
 `;

--- a/src/public/schema/disease/sections/Phenotypes.js
+++ b/src/public/schema/disease/sections/Phenotypes.js
@@ -1,7 +1,5 @@
 import { gql } from 'apollo-server-express';
 
-import { diseaseSimilar } from '../../../apis/openTargets';
-
 export const id = 'phenotypes';
 
 export const summaryTypeDefs = gql`

--- a/src/public/schema/drug/index.js
+++ b/src/public/schema/drug/index.js
@@ -3,81 +3,88 @@ import { gql } from 'apollo-server-express';
 import _ from 'lodash';
 
 // load sections
-// import * as sectionsObject from './sectionIndex';
-// const sections = Object.values(sectionsObject);
+import * as sectionsObject from './sectionIndex';
+const sections = Object.values(sectionsObject);
 
 // combine type defs
-// const summaryTypeDefs = sections.map(d => d.summaryTypeDefs);
-// const sectionTypeDefs = sections.map(d => d.sectionTypeDefs);
-// const summariesTypeDef = gql`
-//   type DiseaseSummaries {
-//     ${sections
-//       .map(d => `${d.id}: DiseaseSummary${_.upperFirst(d.id)}`)
-//       .join('\n')}
-//   }
-// `;
-// const sectionsTypeDef = gql`
-//   type DiseaseDetails {
-//     ${sections
-//       .map(d => `${d.id}: DiseaseDetail${_.upperFirst(d.id)}`)
-//       .join('\n')}
-//   }
-// `;
+const summaryTypeDefs = sections.map(d => d.summaryTypeDefs);
+const sectionTypeDefs = sections.map(d => d.sectionTypeDefs);
+const summariesTypeDef = gql`
+  type DrugSummaries {
+    ${sections
+      .map(d => `${d.id}: DrugSummary${_.upperFirst(d.id)}`)
+      .join('\n')}
+  }
+`;
+const sectionsTypeDef = gql`
+  type DrugDetails {
+    ${sections
+      .map(d => `${d.id}: DrugDetail${_.upperFirst(d.id)}`)
+      .join('\n')}
+  }
+`;
 const drugTypeDef = gql`
   type Drug {
     id: String!
     name: String!
-    description: String!
     synonyms: [String!]!
-    # summaries: DiseaseSummaries!
-    # details: DiseaseDetails!
+    tradeNames: [String!]!
+    yearOfFirstApproval: String
+    type: String!
+    maximumClinicalTrialPhase: Int
+    summaries: DrugSummaries!
+    details: DrugDetails!
   }
 `;
 export const typeDefs = [
-  // ...summaryTypeDefs,
-  // ...sectionTypeDefs,
-  // summariesTypeDef,
-  // sectionsTypeDef,
+  ...summaryTypeDefs,
+  ...sectionTypeDefs,
+  summariesTypeDef,
+  sectionsTypeDef,
   drugTypeDef,
 ];
 
 // merge resolvers
-// const summariesResolvers = sections.map(d => d.summaryResolvers);
-// const sectionsResolvers = sections.map(d => d.sectionResolvers);
-// const summariesResolver = {
-//   DiseaseSummaries: sections.reduce((acc, d) => {
-//     acc[d.id] = _.identity;
-//     return acc;
-//   }, {}),
-// };
-// const sectionsResolver = {
-//   DiseaseDetails: sections.reduce((acc, d) => {
-//     acc[d.id] = _.identity;
-//     return acc;
-//   }, {}),
-// };
+const summariesResolvers = sections.map(d => d.summaryResolvers);
+const sectionsResolvers = sections.map(d => d.sectionResolvers);
+const summariesResolver = {
+  DrugSummaries: sections.reduce((acc, d) => {
+    acc[d.id] = _.identity;
+    return acc;
+  }, {}),
+};
+const sectionsResolver = {
+  DrugDetails: sections.reduce((acc, d) => {
+    acc[d.id] = _.identity;
+    return acc;
+  }, {}),
+};
 const drugResolver = {
   Drug: {
     id: ({ _chemblId, id }, args, { drugLoader }) =>
       id ? id : drugLoader.load(_chemblId).then(({ id }) => id),
     name: ({ _chemblId, name }, args, { drugLoader }) =>
       name ? name : drugLoader.load(_chemblId).then(({ name }) => name),
-    // description: ({ _chemblId, description }, args, { drugLoader }) =>
-    //   description
-    //     ? description
-    //     : drugLoader.load(_chemblId).then(({ description }) => description),
     synonyms: ({ _chemblId, synonyms }, args, { drugLoader }) =>
       synonyms
         ? synonyms
         : drugLoader.load(_chemblId).then(({ synonyms }) => synonyms),
-    // summaries: _.identity,
-    // details: _.identity,
+    maximumClinicalTrialPhase: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ maximumClinicalTrialPhase }) => maximumClinicalTrialPhase),
+    type: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ type }) => type),
+    yearOfFirstApproval: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ yearOfFirstApproval }) => yearOfFirstApproval),
+    tradeNames: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ tradeNames }) => tradeNames),
+    summaries: _.identity,
+    details: _.identity,
   },
 };
 export const resolvers = _.merge(
-  // ...summariesResolvers,
-  // ...sectionsResolvers,
-  // summariesResolver,
-  // sectionsResolver,
+  ...summariesResolvers,
+  ...sectionsResolvers,
+  summariesResolver,
+  sectionsResolver,
   drugResolver
 );

--- a/src/public/schema/drug/sectionIndex.js
+++ b/src/public/schema/drug/sectionIndex.js
@@ -3,6 +3,8 @@
 
 import * as mechanismsOfActionRaw from './sections/MechanismsOfAction';
 import * as linkedTargetsRaw from './sections/LinkedTargets';
+import * as linkedDiseasesRaw from './sections/LinkedDiseases';
 
 export const mechanismsOfAction = mechanismsOfActionRaw;
 export const linkedTargets = linkedTargetsRaw;
+export const linkedDiseases = linkedDiseasesRaw;

--- a/src/public/schema/drug/sectionIndex.js
+++ b/src/public/schema/drug/sectionIndex.js
@@ -1,0 +1,6 @@
+// TODO: see if this can be done dynamically
+//       or try @babel/plugin-proposal-export-namespace-from (may need eject)
+
+import * as mechanismsOfActionRaw from './sections/MechanismsOfAction';
+
+export const mechanismsOfAction = mechanismsOfActionRaw;

--- a/src/public/schema/drug/sectionIndex.js
+++ b/src/public/schema/drug/sectionIndex.js
@@ -2,5 +2,7 @@
 //       or try @babel/plugin-proposal-export-namespace-from (may need eject)
 
 import * as mechanismsOfActionRaw from './sections/MechanismsOfAction';
+import * as linkedTargetsRaw from './sections/LinkedTargets';
 
 export const mechanismsOfAction = mechanismsOfActionRaw;
+export const linkedTargets = linkedTargetsRaw;

--- a/src/public/schema/drug/sections/LinkedDiseases.js
+++ b/src/public/schema/drug/sections/LinkedDiseases.js
@@ -1,0 +1,46 @@
+import { gql } from 'apollo-server-express';
+
+import { drugDiseases } from '../../../apis/openTargets';
+
+export const id = 'linkedDiseases';
+
+// TODO: We should NOT use `drugDiseases`, which essentially looks for
+//       evidence containing the drug name. There will be a new field
+//       `indications` in the 19.09 drug index, which we should switch
+//       to when available.
+
+export const summaryTypeDefs = gql`
+  type DrugSummaryLinkedDiseases {
+    linkedDiseaseCount: Int!
+    sources: [Source!]!
+  }
+`;
+
+export const summaryResolvers = {
+  DrugSummaryLinkedDiseases: {
+    linkedDiseaseCount: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader
+        .load(_chemblId)
+        .then(({ name }) => drugDiseases(name))
+        .then(diseases => diseases.length),
+    sources: () => [
+      {
+        name: 'ChEMBL',
+        url: 'https://www.ebi.ac.uk/chembl/',
+      },
+    ],
+  },
+};
+
+export const sectionTypeDefs = gql`
+  type DrugDetailLinkedDiseases {
+    rows: [Disease!]!
+  }
+`;
+
+export const sectionResolvers = {
+  DrugDetailLinkedDiseases: {
+    rows: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ name }) => drugDiseases(name)),
+  },
+};

--- a/src/public/schema/drug/sections/LinkedTargets.js
+++ b/src/public/schema/drug/sections/LinkedTargets.js
@@ -1,0 +1,38 @@
+import { gql } from 'apollo-server-express';
+
+export const id = 'linkedTargets';
+
+export const summaryTypeDefs = gql`
+  type DrugSummaryLinkedTargets {
+    linkedTargetCount: Int!
+    sources: [Source!]!
+  }
+`;
+
+export const summaryResolvers = {
+  DrugSummaryLinkedTargets: {
+    linkedTargetCount: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader
+        .load(_chemblId)
+        .then(({ linkedTargets }) => linkedTargets.length),
+    sources: () => [
+      {
+        name: 'ChEMBL',
+        url: 'https://www.ebi.ac.uk/chembl/',
+      },
+    ],
+  },
+};
+
+export const sectionTypeDefs = gql`
+  type DrugDetailLinkedTargets {
+    rows: [Target!]!
+  }
+`;
+
+export const sectionResolvers = {
+  DrugDetailLinkedTargets: {
+    rows: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ linkedTargets }) => linkedTargets),
+  },
+};

--- a/src/public/schema/drug/sections/MechanismsOfAction.js
+++ b/src/public/schema/drug/sections/MechanismsOfAction.js
@@ -1,0 +1,45 @@
+import { gql } from 'apollo-server-express';
+
+export const id = 'mechanismsOfAction';
+
+export const summaryTypeDefs = gql`
+  type DrugSummaryMechanismsOfAction {
+    uniqueActionTypes: [String!]!
+    uniqueTargetTypes: [String!]!
+    sources: [Source!]!
+  }
+`;
+
+export const summaryResolvers = {
+  DrugSummaryMechanismsOfAction: {
+    uniqueActionTypes: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ uniqueActionTypes }) => uniqueActionTypes),
+    uniqueTargetTypes: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ uniqueTargetTypes }) => uniqueTargetTypes),
+    sources: () => [
+      {
+        name: 'ChEMBL',
+        url: 'https://www.ebi.ac.uk/chembl/',
+      },
+    ],
+  },
+};
+
+export const sectionTypeDefs = gql`
+  type MechanismOfActionRow {
+    mechanismOfAction: String!
+    targetName: String!
+    targets: [Target!]!
+    references: [Source!]!
+  }
+  type DrugDetailMechanismsOfAction {
+    rows: [MechanismOfActionRow!]!
+  }
+`;
+
+export const sectionResolvers = {
+  DrugDetailMechanismsOfAction: {
+    rows: ({ _chemblId }, args, { drugLoader }) =>
+      drugLoader.load(_chemblId).then(({ mechanismsOfAction }) => mechanismsOfAction),
+  },
+};


### PR DESCRIPTION
This PR adds:
* drug summary/details for `linkedTargets`, `linkedDiseases` and `mechanismsOfAction`
* overview fields for `maximumClinicalTrialPhase`, `type`, `yearOfFirstApproval` and `tradeNames`