### PR TITLE
Textmining: remove relevance adjustment

### DIFF
--- a/src/public/apis/openTargets.js
+++ b/src/public/apis/openTargets.js
@@ -480,7 +480,7 @@ const evidenceTextMiningRowTransformer = r => {
   ]; // preferred sorting order
   return {
     access: r.access_level,
-    relevance: (r.scores.association_score * 5) / 1.66666666,
+    relevance: r.scores.association_score,
     disease: {
       id: r.disease.efo_info.efo_id.split('/').pop(),
       name: r.disease.efo_info.label,


### PR DESCRIPTION
It seems that the score for text mining evidence is not always in the 'weighted' range we thought, with examples going up to 1. Scaling (or 'un-weighting') in the front end causes such examples to appear wrong (off-scale).