### PR TITLE
Fix custom VEP term

### DIFF
--- a/src/public/apis/openTargets.js
+++ b/src/public/apis/openTargets.js
@@ -465,7 +465,10 @@ const cleanVepConsequenceLabel = string =>
   string
     .toUpperCase()
     .replace('5', 'FIVE')
-    .replace('3', 'THREE');
+    .replace('3', 'THREE')
+    .replace('&APOS;', ' PRIME')
+    .replace(/ /g, '_');
+
 const getVepConsequenceLabel = evidenceString => {
   const ecoId = evidenceString.evidence.gene2variant.functional_consequence
     .split('/')

--- a/src/public/schema/evidence/sections/GWASCatalog.js
+++ b/src/public/schema/evidence/sections/GWASCatalog.js
@@ -65,7 +65,7 @@ export const sectionTypeDefs = gql`
     REGULATORY_REGION_VARIANT
     FEATURE_TRUNCATION
     INTERGENIC_VARIANT
-    NEAREST_GENE_FIVE_PRIME_END # this is a fake consequence that we invented
+    NEAREST_GENE_COUNTING_FROM_FIVE_PRIME_END # this is a fake consequence that we invented
   }
   type EvidenceRowGwasCatalog {
     disease: Disease!


### PR DESCRIPTION
Open Targets adds a custom VEP consequence for GWAS Catalog evidence, named `Nearest gene counting from 5&apos; end`. This needs handling to allow the enum value to be `NEAREST_GENE_COUNTING_FROM_FIVE_PRIME_END`.