### PR TITLE
Support retrieval of tractability data for disease associations

### DIFF
--- a/src/public/apis/dataloaders.js
+++ b/src/public/apis/dataloaders.js
@@ -138,32 +138,32 @@ const antibodyTractabilityLevels = [
   //     bucket: 10
   // }
 ];
-const transformTractability = rawTractability => {
+export const transformTractability = rawTractability => {
   let hasSmallMoleculeTractabilityAssessment = false;
   let hasAntibodyTractabilityAssessment = false;
   let smallMolecule = null;
   let antibody = null;
 
-  if (rawTractability.smallmolecule) {
-    hasSmallMoleculeTractabilityAssessment =
-      rawTractability.smallmolecule.buckets.length !== 0;
-    smallMolecule = smallMoleculeTractabilityLevels.map(d => ({
-      chemblBucket: d.bucket,
-      description: d.label,
-      value: rawTractability.smallmolecule.buckets.indexOf(d.bucket) >= 0,
-    }));
-  }
+  hasSmallMoleculeTractabilityAssessment =
+    rawTractability.smallmolecule &&
+    rawTractability.smallmolecule.buckets.length !== 0;
+  smallMolecule = smallMoleculeTractabilityLevels.map(d => ({
+    chemblBucket: d.bucket,
+    description: d.label,
+    value: rawTractability.smallmolecule
+      ? rawTractability.smallmolecule.buckets.indexOf(d.bucket) >= 0
+      : false,
+  }));
 
-  if (rawTractability.antibody) {
-    hasAntibodyTractabilityAssessment =
-      rawTractability.antibody.buckets.length !== 0;
-
-    antibody = antibodyTractabilityLevels.map(d => ({
-      chemblBucket: d.bucket,
-      description: d.label,
-      value: rawTractability.antibody.buckets.indexOf(d.bucket) >= 0,
-    }));
-  }
+  hasAntibodyTractabilityAssessment =
+    rawTractability.antibody && rawTractability.antibody.buckets.length !== 0;
+  antibody = antibodyTractabilityLevels.map(d => ({
+    chemblBucket: d.bucket,
+    description: d.label,
+    value: rawTractability.antibody
+      ? rawTractability.antibody.buckets.indexOf(d.bucket) >= 0
+      : false,
+  }));
 
   return {
     hasSmallMoleculeTractabilityAssessment,

--- a/src/public/schema/target/sections/Tractability.js
+++ b/src/public/schema/target/sections/Tractability.js
@@ -53,13 +53,17 @@ export const sectionTypeDefs = gql`
 
 export const sectionResolvers = {
   TargetDetailTractability: {
-    smallMolecule: ({ _ensgId }, args, { targetLoader }) =>
-      targetLoader
-        .load(_ensgId)
-        .then(({ tractability }) => tractability.smallMolecule),
-    antibody: ({ _ensgId }, args, { targetLoader }) =>
-      targetLoader
-        .load(_ensgId)
-        .then(({ tractability }) => tractability.antibody),
+    smallMolecule: ({ _ensgId, details }, args, { targetLoader }) =>
+      details && details.tractability
+        ? details.tractability.smallMolecule
+        : targetLoader
+            .load(_ensgId)
+            .then(({ tractability }) => tractability.smallMolecule),
+    antibody: ({ _ensgId, details }, args, { targetLoader }) =>
+      details && details.tractability
+        ? details.tractability.antibody
+        : targetLoader
+            .load(_ensgId)
+            .then(({ tractability }) => tractability.antibody),
   },
 };


### PR DESCRIPTION
The disease associations page of `platform-app` needs to show extra tractability columns. This PR adds the necessary support.