### PR TITLE
Fix text mining missing authorList case; issue opentargets/platform#786

### DIFF
--- a/src/public/apis/openTargets.js
+++ b/src/public/apis/openTargets.js
@@ -1262,7 +1262,7 @@ const evidenceTextMiningRowTransformer = r => {
       id: ref.data.pmid || ref.data.pmcid || ref.data.id,
       title: ref.data.title,
       date: ref.data.pubYear,
-      authors: ref.data.authorList.author.map(auth => ({
+      authors: (ref.data.authorList || { author: [] }).author.map(auth => ({
         firstName: auth.firstName || auth.initials || '',
         lastName: auth.lastName,
         initials: auth.initials,


### PR DESCRIPTION
Small PR to handle missing authors list in the EPMC response for the text mining component:
If no authors returned, set an empty list (currently the missing authors causes an error response).
Issue: https://github.com/opentargets/platform/issues/786